### PR TITLE
skip empty annotations

### DIFF
--- a/gene_model/collapse_annotation.py
+++ b/gene_model/collapse_annotation.py
@@ -63,6 +63,8 @@ class Annotation:
                 attributes = defaultdict(list)
                 for a in row[8].replace('"', '').replace('_biotype', '_type').split(';')[:-1]:
                     kv = a.strip().split(' ')
+                    if len(kv) < 2:
+                        continue
                     if kv[0]!='tag':
                         attributes[kv[0]] = kv[1]
                     else:


### PR DESCRIPTION
I was using the "collapse_annotations.py" script to prepare a reference for RNASeQC, as suggested in its docs. I got an error running it on an NCBI genome GTF due to empty annotations, e.g. `transcript_id "";`. The purpose of this PR is to skip empty annotations and allow processing of these files.