### PR TITLE
rnaseq: update samtofastq to version 8

### DIFF
--- a/rnaseq/rnaseq_pipeline_bam.wdl
+++ b/rnaseq/rnaseq_pipeline_bam.wdl
@@ -1,4 +1,4 @@
-import "https://api.firecloud.org/ga4gh/v1/tools/broadinstitute_gtex:samtofastq_v1-0_BETA/versions/7/plain-WDL/descriptor" as samtofastq_wdl
+import "https://api.firecloud.org/ga4gh/v1/tools/broadinstitute_gtex:samtofastq_v1-0_BETA/versions/8/plain-WDL/descriptor" as samtofastq_wdl
 import "https://api.firecloud.org/ga4gh/v1/tools/broadinstitute_gtex:star_v1-0_BETA/versions/8/plain-WDL/descriptor" as star_wdl
 import "https://api.firecloud.org/ga4gh/v1/tools/broadinstitute_gtex:markduplicates_v1-0_BETA/versions/6/plain-WDL/descriptor" as markduplicates_wdl
 import "https://api.firecloud.org/ga4gh/v1/tools/broadinstitute_gtex:rsem_v1-0_BETA/versions/6/plain-WDL/descriptor" as rsem_wdl


### PR DESCRIPTION
Version 7 is no longer accessible via API.