### PR TITLE
Update star.wdl docker to gtex_rnaseq:V11

### DIFF
--- a/rnaseq/star.wdl
+++ b/rnaseq/star.wdl
@@ -128,7 +128,7 @@ task star {
     }
 
     runtime {
-        docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10"
+        docker: "gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V11"
         memory: "${memory}GB"
         disks: "local-disk ${disk_space} HDD"
         cpu: "${num_threads}"


### PR DESCRIPTION
Our lab's bulk RNA-seq pipeline is based on the GTEx RNA-seq pipeline. I encountered an issue with STAR alignment, specifically related to a version change to 2.7.11b and the new parameter --quantTranscriptomeSAMoutput BanSingleEnd_ExtendSoftclip. It turns out that while the docker image pushed was V11, the star.wdl file specified the V10 docker image: gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V10. I have since updated it to gcr.io/broad-cga-francois-gtex/gtex_rnaseq:V11.


